### PR TITLE
Add Mitsuya Cider introduction page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,374 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>三ツ矢サイダー | きらめく炭酸の世界へ</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --primary: #00a4e2;
+      --accent: #7dd9ff;
+      --deep: #00365c;
+      --bg: #f4fbff;
+      --text: #0f2d3a;
+      --card-bg: rgba(255, 255, 255, 0.85);
+      --shadow: 0 20px 40px rgba(0, 63, 104, 0.15);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Hiragino Sans', 'Noto Sans JP', 'Yu Gothic', sans-serif;
+      line-height: 1.7;
+      color: var(--text);
+      background: radial-gradient(circle at 20% 20%, rgba(125, 217, 255, 0.35), transparent 60%),
+                  radial-gradient(circle at 80% 0%, rgba(0, 164, 226, 0.2), transparent 55%),
+                  var(--bg);
+    }
+
+    header {
+      position: relative;
+      overflow: hidden;
+      background: linear-gradient(135deg, rgba(0, 164, 226, 0.85), rgba(0, 54, 92, 0.9)),
+                  url('https://images.unsplash.com/photo-1527169402691-feff5539e52c?auto=format&fit=crop&w=1400&q=80') center/cover;
+      color: #fff;
+      text-align: center;
+      padding: 6rem 1.5rem 7rem;
+      clip-path: ellipse(120% 100% at 50% 0%);
+    }
+
+    header::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(180deg, rgba(255,255,255,0.05), transparent 60%);
+      pointer-events: none;
+    }
+
+    .logo {
+      font-weight: 700;
+      letter-spacing: 0.2em;
+      font-size: 1rem;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      margin: 1.2rem 0 0;
+      font-size: clamp(2.6rem, 7vw, 4.5rem);
+      letter-spacing: 0.08em;
+      text-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+    }
+
+    header p {
+      margin: 1.5rem auto 2.8rem;
+      max-width: 540px;
+      font-size: 1.05rem;
+      letter-spacing: 0.05em;
+    }
+
+    .cta {
+      display: inline-block;
+      padding: 0.85rem 2.6rem;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,0.7);
+      background: rgba(255,255,255,0.2);
+      color: #fff;
+      font-weight: 600;
+      backdrop-filter: blur(6px);
+      transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+      text-decoration: none;
+    }
+
+    .cta:hover {
+      transform: translateY(-3px);
+      box-shadow: 0 20px 35px rgba(0, 0, 0, 0.2);
+      background: rgba(255,255,255,0.32);
+    }
+
+    main {
+      margin-top: -3rem;
+      padding: 0 1.25rem 4rem;
+    }
+
+    .section {
+      max-width: 1080px;
+      margin: 0 auto 4.5rem;
+      background: var(--card-bg);
+      backdrop-filter: blur(14px);
+      padding: clamp(2rem, 4vw, 3rem);
+      border-radius: 28px;
+      box-shadow: var(--shadow);
+    }
+
+    .section h2 {
+      margin-top: 0;
+      font-size: clamp(1.8rem, 4vw, 2.4rem);
+      color: var(--deep);
+      position: relative;
+      padding-left: 1.5rem;
+    }
+
+    .section h2::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      top: 0.4em;
+      width: 6px;
+      height: 60%;
+      background: linear-gradient(180deg, var(--primary), var(--accent));
+      border-radius: 999px;
+    }
+
+    .features {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1.8rem;
+      margin-top: 2rem;
+    }
+
+    .feature-card {
+      padding: 1.8rem;
+      border-radius: 20px;
+      background: linear-gradient(155deg, rgba(255,255,255,0.9), rgba(224,245,255,0.75));
+      box-shadow: 0 15px 35px rgba(0, 120, 180, 0.1);
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    .feature-card:hover {
+      transform: translateY(-6px);
+      box-shadow: 0 25px 40px rgba(0, 80, 120, 0.18);
+    }
+
+    .feature-card h3 {
+      margin-top: 0;
+      color: var(--primary);
+      font-size: 1.25rem;
+    }
+
+    .timeline {
+      position: relative;
+      margin-top: 2.5rem;
+      padding-left: 1.5rem;
+    }
+
+    .timeline::before {
+      content: "";
+      position: absolute;
+      left: 10px;
+      top: 0;
+      bottom: 0;
+      width: 3px;
+      background: linear-gradient(180deg, rgba(0,164,226,0.7), rgba(0,54,92,0.6));
+    }
+
+    .timeline-item {
+      position: relative;
+      padding: 1.2rem 1.2rem 1.2rem 2.8rem;
+      margin-bottom: 1.2rem;
+      background: rgba(255, 255, 255, 0.92);
+      border-radius: 16px;
+      box-shadow: 0 10px 25px rgba(0, 90, 130, 0.08);
+    }
+
+    .timeline-item::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      top: 1.6rem;
+      width: 14px;
+      height: 14px;
+      background: #fff;
+      border: 4px solid var(--primary);
+      border-radius: 50%;
+      transform: translateX(-50%);
+      box-shadow: 0 0 0 4px rgba(0, 164, 226, 0.25);
+    }
+
+    .timeline-item h3 {
+      margin: 0 0 0.4rem;
+      color: var(--deep);
+      font-size: 1.15rem;
+    }
+
+    .lineup {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1.6rem;
+      margin-top: 2.2rem;
+    }
+
+    .lineup-item {
+      background: rgba(255,255,255,0.92);
+      border-radius: 22px;
+      padding: 1.6rem;
+      text-align: center;
+      box-shadow: 0 15px 30px rgba(0, 90, 120, 0.08);
+      transition: transform 0.3s ease;
+    }
+
+    .lineup-item:hover {
+      transform: translateY(-8px);
+    }
+
+    .lineup-item h3 {
+      margin: 0.6rem 0;
+      color: var(--primary);
+    }
+
+    .tips {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.5rem;
+      margin-top: 2rem;
+    }
+
+    .tip {
+      padding: 1.6rem;
+      border-radius: 18px;
+      background: linear-gradient(145deg, rgba(255,255,255,0.95), rgba(224,245,255,0.8));
+      box-shadow: 0 15px 30px rgba(0, 90, 120, 0.09);
+    }
+
+    .tip strong {
+      color: var(--deep);
+      font-size: 1.05rem;
+    }
+
+    footer {
+      text-align: center;
+      padding: 3rem 1rem 2rem;
+      color: rgba(15,45,58,0.7);
+      font-size: 0.9rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #021118;
+        --text: #d8f2ff;
+        --card-bg: rgba(3, 24, 34, 0.7);
+        --shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+      }
+
+      header {
+        background: linear-gradient(135deg, rgba(0, 164, 226, 0.55), rgba(0, 54, 92, 0.85)),
+                    url('https://images.unsplash.com/photo-1527169402691-feff5539e52c?auto=format&fit=crop&w=1400&q=80') center/cover;
+      }
+
+      .timeline::before {
+        background: linear-gradient(180deg, rgba(0,164,226,0.9), rgba(0,54,92,0.8));
+      }
+
+      .timeline-item {
+        background: rgba(5, 35, 50, 0.85);
+      }
+
+      .lineup-item {
+        background: rgba(3, 28, 42, 0.88);
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="logo">Mitsuya Cider</div>
+    <h1>三ツ矢サイダー</h1>
+    <p>1884年の誕生以来、変わらないおいしさと爽やかな炭酸で愛され続ける日本を代表するクリア炭酸飲料。きらめく泡が日常を少し特別にしてくれます。</p>
+    <a class="cta" href="#features">魅力を知る</a>
+  </header>
+
+  <main>
+    <section class="section" id="features">
+      <h2>三ツ矢サイダーが選ばれる理由</h2>
+      <div class="features">
+        <article class="feature-card">
+          <h3>独自の製法</h3>
+          <p>ミネラル分を含む地下水を活用した「磨かれた水」を使用。雑味のない澄んだ味わいを生み出すこだわりの製法で、炭酸のきめ細かな刺激を楽しめます。</p>
+        </article>
+        <article class="feature-card">
+          <h3>フレッシュな香り</h3>
+          <p>ほんのりと香る柑橘系の香りが特徴。後味はすっきりとキレがあり、お食事にも、おやつタイムにも相性抜群です。</p>
+        </article>
+        <article class="feature-card">
+          <h3>安心・安全への追求</h3>
+          <p>保存料・合成着色料ゼロ。細やかな品質管理に支えられた安全性で、お子さまから大人まで安心して飲めるクリアな炭酸です。</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>三ツ矢ブランドの歩み</h2>
+      <div class="timeline">
+        <div class="timeline-item">
+          <h3>1884年 三ツ矢サイダー誕生</h3>
+          <p>兵庫県平野鉱泉の天然炭酸水をルーツに、炭酸飲料としての歴史がスタート。日本人の嗜好に合わせた味わいで人気を集めました。</p>
+        </div>
+        <div class="timeline-item">
+          <h3>1950年代 近代化と全国展開</h3>
+          <p>近代的なボトリング技術を採用し、全国へ供給を拡大。ガラス瓶から缶、ペットボトルへと容器も進化します。</p>
+        </div>
+        <div class="timeline-item">
+          <h3>2004年 ブランドリフレッシュ</h3>
+          <p>120周年を機にロゴとパッケージを刷新。「爽やかさ」「安心感」「信頼感」をさらに磨き上げました。</p>
+        </div>
+        <div class="timeline-item">
+          <h3>現在 伝統と革新の両立</h3>
+          <p>定番の三ツ矢サイダーに加え、季節限定フレーバーやゼロシュガーなど多彩なラインアップで新しい楽しみ方を提案しています。</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>おすすめの楽しみ方</h2>
+      <div class="tips">
+        <div class="tip">
+          <strong>キンキンに冷やして</strong>
+          <p>冷蔵庫でしっかり冷やすと炭酸の刺激がアップ。氷を入れる場合は大きめの角氷でゆっくり溶かすのがコツです。</p>
+        </div>
+        <div class="tip">
+          <strong>フルーツと一緒に</strong>
+          <p>カットした柑橘やベリーを加えれば、手軽なフルーツポンチに。鮮やかな見た目と爽快感でパーティーにもぴったり。</p>
+        </div>
+        <div class="tip">
+          <strong>アレンジドリンクに</strong>
+          <p>紅茶やハーブティーと割ったり、シロップを加えたりとアレンジ自在。大人にはカクテルベースとしても人気です。</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>ラインアップ</h2>
+      <div class="lineup">
+        <div class="lineup-item">
+          <h3>三ツ矢サイダー</h3>
+          <p>定番の味。雑味のないクリアな甘さと爽やかな後味で、世代を問わず愛されるスタンダード。</p>
+        </div>
+        <div class="lineup-item">
+          <h3>三ツ矢サイダー ゼロストロング</h3>
+          <p>糖類ゼロ・カロリーゼロでもしっかりした刺激と飲み応え。健康志向の方にもおすすめです。</p>
+        </div>
+        <div class="lineup-item">
+          <h3>三ツ矢サイダー 期間限定フレーバー</h3>
+          <p>旬の果実をテーマにした期間限定品。季節ごとに異なる香りと味わいが楽しめます。</p>
+        </div>
+        <div class="lineup-item">
+          <h3>三ツ矢フルーツソーダ</h3>
+          <p>果汁をしっかり感じるバリエーション。フルーティーで華やかなひとときを演出します。</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>サステナビリティへの取り組み</h2>
+      <p>三ツ矢ブランドを展開するアサヒ飲料では、ペットボトルのリサイクル強化や環境負荷の少ない工場運営、地域社会との共生など、持続可能な社会の実現に向けた活動を推進しています。日々の小さな一歩が、未来の地球とおいしい時間を守ります。</p>
+    </section>
+  </main>
+
+  <footer>
+    <p>© 2024 Asahi Soft Drinks Co., Ltd. これは三ツ矢サイダーを紹介するファンサイトのデモページです。</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone Mitsuya Cider landing page written in Japanese with hero, feature, timeline, tips, lineup, and sustainability sections
- style the page with gradients, responsive grids, and dark mode adjustments to highlight the brand's refreshing aesthetic

## Testing
- not run (static HTML page)


------
https://chatgpt.com/codex/tasks/task_e_68d5038a286c833396939194fda65367